### PR TITLE
Add warning that `data/` directory needs to be writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To require authentication, first create a password file:
 
 Then copy `./example.htaccess` to `.htaccess` and edit it.
 
+Ensure that the `data/` directory and files therein are writable by the user/group running PHP.
+
 ### Multi-user ###
 
 If you have multiple users, clone the directory for each user and create a unique htaccess login for each.


### PR DESCRIPTION
I installed todomini (which is great, btw) on my server and found that my edits were not surviving a browser refresh. Making the `data/` directory writable by all users fixed the problem, but allowing my edits to be persisted on the server.

Of course, the more correct way to do this is to ensure that the user under which PHP is running has write permission to the `data/` directory and I've added this suggestion to the README.